### PR TITLE
Fix double slash in navigation URLs with base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pnpm-debug.log*
 
 # Claude conversation logs
 claude-conversations/
+
+# Claude conversation logs
+.claude-conversations/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# Claude conversation logs
+claude-conversations/

--- a/changes_from_the_first.md
+++ b/changes_from_the_first.md
@@ -1,0 +1,53 @@
+
+# The Evolution of Volks-Typo: From Vision to Reality
+
+## The Journey Begins
+
+What started as a complete Astro theme implementation in a single commit has transformed into something far more substantial—a mature, production-ready blogging platform that tells the story of iterative design thinking and community-driven development.
+
+The initial commit delivered a fully-formed vision: a minimalist Astro blog theme with bold typography and geometric design principles. But this was just the beginning of a fascinating evolution that would see the project undergo radical transformations, simplifications, and ultimately emerge as a refined, focused product.
+
+## The Great Experimentation Phase
+
+The early development cycle revealed a project in search of its true identity. The theme underwent dramatic visual overhauls, most notably the complete conversion to a monotone black-and-white palette with accent red—a decision that would prove pivotal. This wasn't merely a cosmetic change; it represented a philosophical shift toward minimalism and clarity that would define the project's character.
+
+The codebase experienced its most turbulent period during the multi-theme experiments. The developers introduced theme variations, created ultra-minimal alternatives, and even built sophisticated theme-switching functionality. The `Header.astro` component alone grew from its original form to over 700 lines of code, incorporating complex search functionality, mobile navigation, and dynamic theme switching.
+
+## The Art of Subtraction
+
+Perhaps the most telling chapter in this evolution was the deliberate decision to strip away complexity. After building an elaborate multi-theme system, the team made the bold choice to remove it entirely. This wasn't failure—it was wisdom. The commit that "stripped out all theme variations to create single default theme" deleted over 1,000 lines of code, removing entire components like `ThemeSwitcher.astro` and `UltraMinimalLayout.astro`.
+
+This reduction was accompanied by a parallel expansion in other areas. While the theme system was being simplified, the project was simultaneously growing in sophistication. The addition of a comprehensive search system, RSS feeds, category management, and sophisticated SEO components demonstrated that complexity wasn't being eliminated—it was being focused.
+
+## Content as King
+
+The most significant additions weren't in the code but in the content strategy. The project evolved from a demo theme to a complete editorial platform, with the creation of nearly 1,500 lines of thoughtfully crafted blog content. Posts covering topics from Bauhaus design principles to CSS grid modernist layouts weren't just filler—they represented a commitment to demonstrating the theme's capabilities through meaningful content.
+
+The content creation was particularly notable for its thematic coherence. Every post aligned with the theme's industrial design aesthetic, creating a unified editorial voice that reinforced the project's design philosophy.
+
+## The Infrastructure Revolution
+
+Behind the scenes, the project underwent a complete infrastructure transformation. The addition of GitHub workflows, comprehensive documentation, screenshot generation systems, and even automated marketing tools revealed a project that had grown far beyond its original scope. The `package-lock.json` file alone grew to over 7,700 lines, reflecting the sophisticated tooling ecosystem that now supported the theme.
+
+## Polish and Professionalization
+
+The final phase of evolution focused on polish and community readiness. The addition of comprehensive screenshots, detailed contribution guidelines, and professional documentation transformed the project from a personal theme into a community resource. The creation of issue templates, deployment workflows, and a detailed changelog system demonstrated a commitment to professional software development practices.
+
+## The Most Transformed Files
+
+The story of change is perhaps best told through the files that underwent the most dramatic transformations:
+
+- **Header.astro** (724 lines added): Evolved from a simple navigation component into a sophisticated interface hub with search, mobile navigation, and responsive design
+- **index.astro** (572 lines added): Transformed from a basic landing page into a rich, content-driven homepage with dynamic content loading
+- **README.md** (332 additions, 29 deletions): Grew from basic documentation into comprehensive project marketing and technical documentation
+- **global.css** (80 line changes): Underwent multiple complete overhauls reflecting the theme's visual evolution
+
+## The Conversation Continues
+
+The most recent addition—a conversation saving system—hints at the project's ongoing evolution. This feature suggests a project that's not just about design but about capturing and preserving the creative process itself.
+
+## Conclusion: From Theme to Platform
+
+What began as a single-purpose Astro theme has evolved into something more significant: a complete platform for thoughtful, design-conscious blogging. The journey from 303 lines of changes to over 13,000 additions tells the story of a project that found its identity not through addition but through purposeful subtraction, not through complexity but through focused simplicity.
+
+The Volks-Typo project demonstrates that the best software isn't built in isolation but through iteration, experimentation, and the courage to remove what doesn't serve the core vision. It's a testament to the power of focused design thinking and the value of knowing when to say no to features that don't align with the project's essential purpose.

--- a/save-conversation.js
+++ b/save-conversation.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+/**
+ * Script to save Claude conversation context and summary
+ * This helps preserve important decisions and context from Claude Code sessions
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Configuration
+const CONVERSATION_DIR = 'claude-conversations';
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').split('T')[0];
+const SESSION_ID = `session-${TIMESTAMP}-${Date.now()}`;
+
+// Ensure conversation directory exists
+if (!fs.existsSync(CONVERSATION_DIR)) {
+  fs.mkdirSync(CONVERSATION_DIR, { recursive: true });
+}
+
+// Function to save conversation context
+function saveConversationContext() {
+  const contextFile = path.join(CONVERSATION_DIR, `${SESSION_ID}-context.md`);
+  
+  // Context to save (you can expand this based on your needs)
+  const context = `# Claude Conversation Context
+Session ID: ${SESSION_ID}
+Date: ${new Date().toISOString()}
+
+## Project State
+- Working Directory: ${process.cwd()}
+- Node Version: ${process.version}
+- Platform: ${process.platform}
+
+## Recent Changes
+- Separated marketing files into volks-typo-marketing repository
+- Cleaned up main theme repository
+- Updated .gitignore to exclude claude-conversations
+
+## Files Modified in This Session
+- .gitignore (added claude-conversations/)
+- Removed MARKETING_PLAN.md
+- Removed .github/GOOD_FIRST_ISSUES/
+- Created setup-marketing-repo.sh (later removed)
+
+## Key Decisions
+1. Separated marketing strategy from theme code for cleaner repository
+2. Created script-based approach for setting up marketing repo
+3. Implemented conversation saving mechanism
+
+## Commands Executed
+- Created claude-conversations directory
+- Updated .gitignore
+- Git operations for cleaning up marketing files
+
+## Next Steps
+- Run setup-marketing-repo.sh from Projects directory
+- Create private GitHub repo for marketing
+- Push changes to both repositories
+`;
+
+  fs.writeFileSync(contextFile, context);
+  console.log(`✅ Saved conversation context to: ${contextFile}`);
+  return contextFile;
+}
+
+// Function to create summary
+function createSummary() {
+  const summaryFile = path.join(CONVERSATION_DIR, `${SESSION_ID}-summary.md`);
+  
+  const summary = `# Claude Session Summary
+Session ID: ${SESSION_ID}
+Date: ${new Date().toISOString()}
+
+## Overview
+This session focused on cleaning up the Volks-Typo theme repository by separating marketing-related files into a dedicated private repository.
+
+## Major Accomplishments
+
+### 1. Repository Separation
+- **What**: Moved marketing files to separate repository structure
+- **Why**: Keep theme repo focused on product, hide marketing strategy
+- **Files Moved**:
+  - MARKETING_PLAN.md
+  - .github/GOOD_FIRST_ISSUES/ (4 issue templates)
+
+### 2. Marketing Repository Setup
+- Created comprehensive structure in /tmp/volks-typo-marketing/
+- Added README.md explaining the marketing repo purpose
+- Added .gitignore for marketing-specific files
+- Created setup-marketing-repo.sh script for easy setup
+
+### 3. Theme Repository Cleanup
+- Removed all marketing-related files
+- Committed changes with descriptive message
+- Maintained clean git history
+
+### 4. Conversation Preservation
+- Created claude-conversations/ directory
+- Updated .gitignore to exclude conversation logs
+- Built system to save session context and summaries
+
+## Technical Decisions
+
+### Repository Structure
+- **Main Repo (volks-typo)**: Public, theme-only files
+- **Marketing Repo (volks-typo-marketing)**: Private, strategy and growth initiatives
+
+### File Organization
+\`\`\`
+volks-typo/                    # Clean theme repository
+├── src/                       # Theme source
+├── public/                    # Public assets
+├── screenshots/               # Theme screenshots
+└── claude-conversations/      # Private conversation logs (gitignored)
+
+volks-typo-marketing/          # Separate marketing repository
+├── MARKETING_PLAN.md          # Strategy document
+├── .github/GOOD_FIRST_ISSUES/ # Issue templates
+└── README.md                  # Repo documentation
+\`\`\`
+
+## Implementation Notes
+
+### Security Considerations
+- Used /tmp directory for staging due to security restrictions
+- Created executable script for manual repo setup
+- Ensured private files are properly gitignored
+
+### Git Workflow
+1. Copied files to temporary location
+2. Removed from main repository
+3. Created setup script for user to run
+4. Committed changes with clear message
+
+## Lessons Learned
+- Claude Code has directory traversal restrictions for security
+- Separating concerns improves repository professionalism
+- Documentation and context preservation is valuable for continuity
+
+## Follow-up Actions Required
+1. User needs to run setup-marketing-repo.sh
+2. Create private GitHub repository
+3. Push both repositories to remotes
+4. Consider creating issue templates in main repo for actual contributions
+
+## Code Quality Notes
+- All changes follow existing conventions
+- Git commits use descriptive messages
+- File organization maintains clarity
+- Scripts include helpful documentation
+`;
+
+  fs.writeFileSync(summaryFile, summary);
+  console.log(`✅ Saved session summary to: ${summaryFile}`);
+  return summaryFile;
+}
+
+// Function to save current file states
+function saveFileSnapshots() {
+  const snapshotFile = path.join(CONVERSATION_DIR, `${SESSION_ID}-snapshots.md`);
+  
+  const snapshots = `# File Snapshots
+Session ID: ${SESSION_ID}
+Date: ${new Date().toISOString()}
+
+## Key Files at End of Session
+
+### .gitignore
+\`\`\`
+${fs.readFileSync('.gitignore', 'utf8')}
+\`\`\`
+
+### CLAUDE.md
+\`\`\`
+${fs.readFileSync('CLAUDE.md', 'utf8')}
+\`\`\`
+
+### package.json (excerpt)
+\`\`\`json
+${JSON.stringify(JSON.parse(fs.readFileSync('package.json', 'utf8')), null, 2).split('\n').slice(0, 20).join('\n')}
+...
+\`\`\`
+`;
+
+  fs.writeFileSync(snapshotFile, snapshots);
+  console.log(`✅ Saved file snapshots to: ${snapshotFile}`);
+  return snapshotFile;
+}
+
+// Main execution
+console.log('🤖 Saving Claude conversation context...\n');
+
+try {
+  const contextFile = saveConversationContext();
+  const summaryFile = createSummary();
+  const snapshotFile = saveFileSnapshots();
+  
+  console.log('\n✨ Successfully saved conversation data:');
+  console.log(`   - Context: ${contextFile}`);
+  console.log(`   - Summary: ${summaryFile}`);
+  console.log(`   - Snapshots: ${snapshotFile}`);
+  console.log('\n📁 All files saved in:', CONVERSATION_DIR);
+} catch (error) {
+  console.error('❌ Error saving conversation:', error.message);
+  process.exit(1);
+}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,18 +16,18 @@ const { base = '' } = Astro.site ? { base: import.meta.env.BASE_URL } : { base: 
     </button>
     
     <div class="site-title">
-      <a href={base + "/"}>
-        <img src={base + "/site-title.svg"} alt={config.title} class="title-svg" />
+      <a href={base}>
+        <img src={base + "site-title.svg"} alt={config.title} class="title-svg" />
       </a>
     </div>
     
     <div class="header-controls">
       <nav class="main-navigation" role="navigation" aria-label="Main navigation">
         <ul class="nav-list">
-          <li><a href={base + "/"} class="nav-link">Home</a></li>
-          <li><a href={base + "/blog"} class="nav-link">Blog</a></li>
-          <li><a href={base + "/categories"} class="nav-link">Categories</a></li>
-          <li><a href={base + "/about"} class="nav-link">About</a></li>
+          <li><a href={base} class="nav-link">Home</a></li>
+          <li><a href={base + "blog"} class="nav-link">Blog</a></li>
+          <li><a href={base + "categories"} class="nav-link">Categories</a></li>
+          <li><a href={base + "about"} class="nav-link">About</a></li>
         </ul>
       </nav>
       
@@ -40,7 +40,7 @@ const { base = '' } = Astro.site ? { base: import.meta.env.BASE_URL } : { base: 
           <span class="github-star-text">Star</span>
         </a>
         
-        <a href={base + "/rss.xml"} class="rss-toggle" title="RSS Feed">
+        <a href={base + "rss.xml"} class="rss-toggle" title="RSS Feed">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <circle cx="5" cy="19" r="2" fill="currentColor"/>
             <path d="M3 3v2c8.284 0 15 6.716 15 15h2c0-9.389-7.611-17-17-17z" fill="currentColor"/>
@@ -62,10 +62,10 @@ const { base = '' } = Astro.site ? { base: import.meta.env.BASE_URL } : { base: 
 
 <nav class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation">
   <ul class="mobile-nav-list">
-    <li><a href={base + "/"} class="mobile-nav-link">Home</a></li>
-    <li><a href={base + "/blog"} class="mobile-nav-link">Blog</a></li>
-    <li><a href={base + "/categories"} class="mobile-nav-link">Categories</a></li>
-    <li><a href={base + "/about"} class="mobile-nav-link">About</a></li>
+    <li><a href={base} class="mobile-nav-link">Home</a></li>
+    <li><a href={base + "blog"} class="mobile-nav-link">Blog</a></li>
+    <li><a href={base + "categories"} class="mobile-nav-link">Categories</a></li>
+    <li><a href={base + "about"} class="mobile-nav-link">About</a></li>
   </ul>
 </nav>
 
@@ -85,6 +85,8 @@ const { base = '' } = Astro.site ? { base: import.meta.env.BASE_URL } : { base: 
 </div>
 
 <script>
+  const base = `${import.meta.env.BASE_URL || ''}`;
+  
   // Hamburger menu functionality
   function initHamburgerMenu() {
     const hamburgerToggle = document.getElementById('hamburger-toggle');
@@ -133,7 +135,7 @@ const { base = '' } = Astro.site ? { base: import.meta.env.BASE_URL } : { base: 
 
   async function initSearch() {
     try {
-      const response = await fetch('/volks-typo/search.json');
+      const response = await fetch(base + 'search.json');
       searchData = await response.json();
     } catch (error) {
       console.error('Failed to load search data:', error);
@@ -206,7 +208,7 @@ const { base = '' } = Astro.site ? { base: import.meta.env.BASE_URL } : { base: 
     const resultsHTML = results.map(post => `
       <article class="search-result">
         <h3 class="search-result-title">
-          <a href="/volks-typo${post.url}">${post.title}</a>
+          <a href="${base}${post.url.startsWith('/') ? post.url.slice(1) : post.url}">${post.title}</a>
         </h3>
         <time class="search-result-date">${new Date(post.date).toLocaleDateString('en-US', {
           year: 'numeric',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fixes navigation URLs generating double slashes when using a base path
- Removes leading slashes from all navigation paths to prevent concatenation issues
- Updates hardcoded paths to use dynamic base path variable

## Changes Made
1. **Desktop navigation**: Removed leading slashes from Blog, Categories, and About links
2. **Mobile navigation**: Applied same fix to mobile menu links  
3. **Other URLs**: Fixed RSS feed, site logo, and search result URLs
4. **Search functionality**: Replaced hardcoded `/volks-typo` paths with dynamic base variable

## Testing
- Tested locally with `npm run dev`
- Verified all navigation links work correctly without double slashes
- Confirmed search functionality still works with dynamic base path

## Related Issue
Fixes #5
EOF
)