### PR TITLE
feat: Add reading time calculation

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,10 +1,15 @@
 ---
 import Layout from '../components/Layout.astro';
+import { calculateReadingTime, extractTextFromMarkdown } from '../utils/reading-time';
 
 const base = import.meta.env.BASE_URL;
 
 const allPosts = await Astro.glob('../content/blog/*.md');
-const sortedPosts = allPosts
+const postsWithReadingTime = allPosts.map(post => ({
+  ...post,
+  readingTime: calculateReadingTime(extractTextFromMarkdown(post.rawContent()))
+}));
+const sortedPosts = postsWithReadingTime
   .sort((a, b) => new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime());
 ---
 
@@ -34,6 +39,8 @@ const sortedPosts = allPosts
                   day: 'numeric'
                 })}
               </time>
+              
+              <span class="post-reading-time">{post.readingTime}</span>
               
               {post.frontmatter.categories && (
                 <div class="post-categories">
@@ -148,6 +155,20 @@ const sortedPosts = allPosts
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  .post-reading-time {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .post-reading-time::before {
+    content: "•";
+    margin: 0 calc(var(--grid-unit));
+    color: var(--color-border);
   }
 
   .post-categories {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,16 +1,22 @@
 ---
 import Layout from '../../components/Layout.astro';
+import { calculateReadingTime, extractTextFromMarkdown } from '../../utils/reading-time';
 
 export async function getStaticPaths() {
   const posts = await Astro.glob('../../content/blog/*.md');
   
-  return posts.map(post => ({
-    params: { slug: post.file.split('/').pop()?.replace('.md', '') },
-    props: { post }
-  }));
+  return posts.map(post => {
+    const plainText = extractTextFromMarkdown(post.rawContent());
+    const readingTime = calculateReadingTime(plainText);
+    
+    return {
+      params: { slug: post.file.split('/').pop()?.replace('.md', '') },
+      props: { post, readingTime }
+    };
+  });
 }
 
-const { post } = Astro.props;
+const { post, readingTime } = Astro.props;
 const { frontmatter, Content } = post;
 
 const pageTitle = frontmatter.title;
@@ -36,6 +42,8 @@ const publishedTime = frontmatter.date ? new Date(frontmatter.date).toISOString(
             day: 'numeric'
           })}
         </time>
+        
+        <span class="post-reading-time">{readingTime}</span>
         
         {frontmatter.categories && frontmatter.categories.length > 0 && (
           <div class="post-categories">
@@ -113,6 +121,20 @@ const publishedTime = frontmatter.date ? new Date(frontmatter.date).toISOString(
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  .post-reading-time {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .post-reading-time::before {
+    content: "•";
+    margin: 0 calc(var(--grid-unit));
+    color: var(--color-border);
   }
 
   .post-categories {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,13 @@
 ---
 import Layout from '../components/Layout.astro';
+import { calculateReadingTime, extractTextFromMarkdown } from '../utils/reading-time';
 
 const recentPosts = await Astro.glob('./blog/*.md');
-const sortedPosts = recentPosts
+const postsWithReadingTime = recentPosts.map(post => ({
+  ...post,
+  readingTime: calculateReadingTime(extractTextFromMarkdown(post.rawContent()))
+}));
+const sortedPosts = postsWithReadingTime
   .sort((a, b) => new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime())
   .slice(0, 3);
 ---
@@ -43,13 +48,16 @@ const sortedPosts = recentPosts
                   <a href={post.url}>{post.frontmatter.title}</a>
                 </h3>
                 
-                <time class="demo-post-date" datetime={post.frontmatter.date}>
-                  {new Date(post.frontmatter.date).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
-                </time>
+                <div class="demo-post-meta">
+                  <time class="demo-post-date" datetime={post.frontmatter.date}>
+                    {new Date(post.frontmatter.date).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    })}
+                  </time>
+                  <span class="demo-post-reading-time">{post.readingTime}</span>
+                </div>
                 
                 {post.frontmatter.excerpt && (
                   <p class="demo-post-excerpt">{post.frontmatter.excerpt}</p>
@@ -465,14 +473,34 @@ cd volks-typo</code></pre>
     color: var(--color-accent);
   }
 
+  .demo-post-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: calc(var(--grid-unit));
+    margin-bottom: calc(var(--grid-unit) * 1.5);
+  }
+
   .demo-post-date {
     font-family: var(--font-mono);
     font-size: 0.85rem;
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    display: block;
-    margin-bottom: calc(var(--grid-unit) * 1.5);
+  }
+
+  .demo-post-reading-time {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .demo-post-reading-time::before {
+    content: "•";
+    margin: 0 calc(var(--grid-unit) / 2);
+    color: var(--color-border);
   }
 
   .demo-post-excerpt {

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,31 @@
+export function calculateReadingTime(text: string): string {
+  // Average reading speed: 200 words per minute for technical content
+  const wordsPerMinute = 200;
+  const words = text.trim().split(/\s+/).length;
+  const minutes = Math.ceil(words / wordsPerMinute);
+  
+  if (minutes < 1) return 'Less than 1 min read';
+  if (minutes === 1) return '1 min read';
+  return `${minutes} min read`;
+}
+
+export function extractTextFromMarkdown(content: string): string {
+  // Remove frontmatter
+  const withoutFrontmatter = content.replace(/^---[\s\S]*?---/, '');
+  
+  // Remove code blocks
+  const withoutCode = withoutFrontmatter.replace(/```[\s\S]*?```/g, '');
+  
+  // Remove inline code
+  const withoutInlineCode = withoutCode.replace(/`[^`]*`/g, '');
+  
+  // Remove markdown syntax
+  const plainText = withoutInlineCode
+    .replace(/#{1,6}\s/g, '') // headers
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
+    .replace(/[*_~]/g, '') // emphasis
+    .replace(/>\s/g, '') // blockquotes
+    .replace(/\|/g, ' '); // tables
+  
+  return plainText;
+}


### PR DESCRIPTION
## Summary
- Added reading time calculation utility that estimates reading duration based on word count
- Integrated reading time display into blog posts, blog listing page, and homepage
- Reading time appears next to post dates with a bullet separator

## Implementation Details
- Created `reading-time.ts` utility with functions to extract text from markdown and calculate reading time
- Updated blog post template to show reading time in post meta
- Updated blog listing page to show reading time for each post
- Updated homepage demo section to show reading time for recent posts
- Consistent styling across all implementations using monospace font and muted color

## Test Plan
- [x] Verify reading time appears on individual blog posts
- [x] Verify reading time appears on blog listing page
- [x] Verify reading time appears on homepage demo section
- [x] Test with posts of varying lengths to ensure accurate calculations
- [x] Ensure responsive design works properly